### PR TITLE
Fix: Apply cursor pagination to feed API

### DIFF
--- a/src/main/java/com/clone/instagram/domain/comment/model/Comment.java
+++ b/src/main/java/com/clone/instagram/domain/comment/model/Comment.java
@@ -11,6 +11,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -48,11 +49,15 @@ public class Comment {
 
     private boolean deleted = false;
 
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
     public Comment(String content, Users writer, Posts post, Comment originalComment) {
         this.content = content;
         this.writer = writer;
         this.post = post;
         this.originalComment = originalComment;
+        this.createdAt = LocalDateTime.now();
     }
 
     public Comment() {}

--- a/src/main/java/com/clone/instagram/domain/post/api/PostController.java
+++ b/src/main/java/com/clone/instagram/domain/post/api/PostController.java
@@ -1,6 +1,7 @@
 package com.clone.instagram.domain.post.api;
 
 import com.clone.instagram.domain.post.dto.*;
+import com.clone.instagram.domain.post.repository.PostRepositoryCustom;
 import com.clone.instagram.domain.post.service.PostService;
 import com.clone.instagram.domain.result.ResultCode;
 import com.clone.instagram.domain.result.ResultResponse;
@@ -18,6 +19,8 @@ public class PostController {
     private static final int DEFAULT_SIZE = 12;
     @Autowired
     private PostService postService;
+    @Autowired
+    private PostRepositoryCustom postRepositoryCustom;
 
     @PostMapping("/posts")
     public ResultResponse create(@RequestBody CreatePostRequest request) {
@@ -41,7 +44,7 @@ public class PostController {
                                                        @RequestParam(required = false) String sortBy,
                                                        @RequestParam(required = false) String sortOrder) {
         if (cursor == null) {
-            cursor = new PostCursor(Long.MAX_VALUE, LocalDateTime.now());
+            cursor = new PostCursor(postRepositoryCustom.findOldestPostId(), LocalDateTime.now());
         }
         int pageSize = (limit != null) ? limit : DEFAULT_SIZE;
         PostSearchCondition condition = new PostSearchCondition(cursor, pageSize, sortBy, sortOrder);

--- a/src/main/java/com/clone/instagram/domain/post/api/PostController.java
+++ b/src/main/java/com/clone/instagram/domain/post/api/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
                                                        @RequestParam(required = false) String sortBy,
                                                        @RequestParam(required = false) String sortOrder) {
         if (cursor == null) {
-            cursor = new PostCursor(postRepositoryCustom.findOldestPostId(), LocalDateTime.now());
+            cursor = new PostCursor(postRepositoryCustom.findLatestPostId(), LocalDateTime.now());
         }
         int pageSize = (limit != null) ? limit : DEFAULT_SIZE;
         PostSearchCondition condition = new PostSearchCondition(cursor, pageSize, sortBy, sortOrder);

--- a/src/main/java/com/clone/instagram/domain/post/dto/PostCursor.java
+++ b/src/main/java/com/clone/instagram/domain/post/dto/PostCursor.java
@@ -2,7 +2,6 @@ package com.clone.instagram.domain.post.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -11,4 +10,5 @@ import java.time.LocalDateTime;
 public class PostCursor {
     private Long id;
     private LocalDateTime createdAt;
+    PostCursor(){}
 }

--- a/src/main/java/com/clone/instagram/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clone/instagram/domain/post/dto/PostResponse.java
@@ -1,27 +1,39 @@
 package com.clone.instagram.domain.post.dto;
 
 import com.clone.instagram.domain.comment.model.Comment;
+import com.clone.instagram.domain.post.model.PostImage;
 import com.clone.instagram.domain.post.model.Posts;
 import com.clone.instagram.domain.user.model.Users;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class PostResponse {
     private Long postId;
     private String content;
+    private List<String> imageUrls;
     private Users user;
     private List<Comment> comments;
 
     public static PostResponse of(Posts post) {
+        List<PostImage> images = post.getImages();
+        List<String> imageUrls = images.stream()
+                .map(PostImage::getImageUrl)
+                .collect(Collectors.toList());
+        List<Comment> comments = post.getComments().stream()
+                .filter(comment -> !comment.isDeleted() && (comment.getOriginalComment() == null))
+                .collect(Collectors.toList());
+
         PostResponse postResponse = PostResponse.builder()
                 .postId(post.getId())
                 .content(post.getContent())
+                .imageUrls(imageUrls)
                 .user(post.getWriter())
-//                .comments()
+                .comments(comments)
                 .build();
         return postResponse;
     }

--- a/src/main/java/com/clone/instagram/domain/post/model/Posts.java
+++ b/src/main/java/com/clone/instagram/domain/post/model/Posts.java
@@ -1,12 +1,12 @@
 package com.clone.instagram.domain.post.model;
 
+import com.clone.instagram.domain.comment.model.Comment;
 import com.clone.instagram.domain.post.dto.CreatePostRequest;
 import com.clone.instagram.domain.user.model.Users;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +26,8 @@ public class Posts {
     private Users writer;
     private Boolean deleted = false;
     private LocalDateTime createdAt;
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<Comment> comments = new ArrayList<>();
     public Posts() {}
 
     public Posts(String content, Users writer) {
@@ -75,4 +77,5 @@ public class Posts {
         // 새 이미지 추가
         updatedImages.forEach(this::addImage);
     }
+
 }

--- a/src/main/java/com/clone/instagram/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/clone/instagram/domain/post/repository/PostRepositoryCustom.java
@@ -18,7 +18,7 @@ import static com.clone.instagram.domain.post.model.QPosts.posts;
 public class PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
-    public Long findOldestPostId() {
+    public Long findLatestPostId() {
         return queryFactory.select(posts.id)
                 .from(posts)
                 .orderBy(posts.createdAt.asc())

--- a/src/main/java/com/clone/instagram/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/clone/instagram/domain/post/repository/PostRepositoryCustom.java
@@ -1,33 +1,37 @@
 package com.clone.instagram.domain.post.repository;
 
-import com.clone.instagram.domain.post.dto.PostCursor;
 import com.clone.instagram.domain.post.dto.PostResponse;
 import com.clone.instagram.domain.post.dto.PostSearchCondition;
 import com.clone.instagram.domain.post.model.Posts;
 import com.clone.instagram.domain.user.model.Users;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.clone.instagram.domain.post.model.QPosts.posts;
-import static com.querydsl.jpa.JPAExpressions.selectFrom;
 
 @Repository
 @RequiredArgsConstructor
 public class PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
+    public Long findOldestPostId() {
+        return queryFactory.select(posts.id)
+                .from(posts)
+                .orderBy(posts.createdAt.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
     public List<PostResponse> findPostsByCondition(PostSearchCondition condition, Users writer) {
-        List<Posts> postsList = selectFrom(posts)
-                .where(posts.createdAt.loe(condition.getCursor().getCreatedAt()),
-                        posts.id.lt(condition.getCursor().getId()),
-                        posts.writer.eq(writer))
-                .orderBy(posts.createdAt.desc(), posts.id.desc())
-                .limit(condition.getPageSize() + 1)
+        List<Posts> postsList = queryFactory.selectFrom(posts)
+                .where(posts.id.goe(condition.getCursor().getId()),
+                        posts.writer.id.eq(writer.getId()))
+                .orderBy(posts.id.desc())
+                .limit(condition.getPageSize())
                 .fetch();
 
         List<PostResponse> content = postsList.stream()


### PR DESCRIPTION
## PR Type
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경변수, 빌드 업데이트

## 개요
+ 피드 조회 API cursor pagination 적용

## 변경 사항
+ 최초 조회시 PostCursor id 없을 경우 가장 최신의 피드 조회
+ images, comments 함께 조회되도록 PostResponse response dto 수정

## 리뷰 받고 싶은 사항
+ 
